### PR TITLE
modified calcFD_save.m and calcFD.m to read label names

### DIFF
--- a/calcFD/calcFD.m
+++ b/calcFD/calcFD.m
@@ -3,7 +3,7 @@ function [fd,subjects] = calcFD(subjects,subjectpath,options)
 % Designed to work with intermediate files from FreeSurfer analysis pipeline
 %   (ribbon.mgz, aparc.a2009s+aseg.mgz).
 % Also can use other mgz volume as input (e.g., see 'benchmark folder').
-% 
+%
 % See 'wrapper_sample.m' for an example of how to use the calcFD toolbox.
 %
 % REQUIRED INPUTS:
@@ -22,72 +22,90 @@ function [fd,subjects] = calcFD(subjects,subjectpath,options)
 %
 % options.aparc = 'Ribbon' | 'Dest_aparc' | 'Dest_select' | 'DKT' | 'none'
 %                 'Ribbon'      == Cortical Ribbon (unparcellated)
-%                 'Dest_aparc'  == Parcellated cortical regions (Destrieux) 
+%                 'Dest_aparc'  == Parcellated cortical regions (Destrieux)
 %                                   ** requires options.input.
-%                 'Dest_select' == Any region in the aparc.a2009s+aseg.mgz volume, 
+%                 'Dest_select' == Any region in the aparc.a2009s+aseg.mgz volume,
 %                                   ** requires options.input.
 %                 'DKT'         == Parcellated cortical regions (DKT).
 %                                   ** requires aparc.DKTaltas40+aseg.mgz to exist.
 %                                   The volume can be generated using:
 %                                   mri_aparc2aseg --s [SUBJECTID] --annot aparc.DKTatlas40
-%                                   See Madan & Kensinger (2017, Brain Informatics) for further details. 
-%                 'none'        == Binarized volume to be manually entered 
+%                                   See Madan & Kensinger (2017, Brain Informatics) for further details.
+%                 'none'        == Binarized volume to be manually entered
 %                                   (e.g., benchmark volumes).
 %
 % options.input = filename string, required for 'Dest_aparc' and 'Dest_select
 %               if options.aparc == 'Dest_aparc'
-%                   This should be a file with the name 'mask_*.txt', 
+%                   This should be a file with the name 'mask_*.txt',
 %                       where * is the value in options.input.
 %                   File should have either 74 or 148 rows, only 1 column.
 %                       If only 74 values, labels are assigned bilaterally.
-%                   Value in each row is the label to assign to that parcellated region, 
+%                   Value in each row is the label to assign to that parcellated region,
 %                       based on the Destrieux et al. (2010) parcellation scheme.
 %                   See 'mask_lobe.txt' for an example.
 %                   See 'calcFD_mask.xlsx' for a list of which regions correspond to each row number.
 %               --
 %               if options.aparc == 'Dest_select'
-%                   This should be a file with the name 'select_*.txt', 
+%                   This should be a file with the name 'select_*.txt',
 %                       where * is the value in options.input.
 %                   Regions correspond to intensity values in aparc.a2009s+aseg.mgz.
-%                   See FreeSurfer files (e.g., FreeSurferColorLUT.txt, ASegStatsLUT.txt, 
+%                   See FreeSurfer files (e.g., FreeSurferColorLUT.txt, ASegStatsLUT.txt,
 %                       WMParcStatsLUT.txt) for mapping of region intensities to names.
 %                   Multiple region values on the same row will be processed as a single structure.
 %                   Currently cannot use the same region in more than one row,
 %                       if need to violate this, use multiple input text files.
 %                   See 'select_subcort.txt' and 'select_ventricles.txt' for examples.
-% 
+%
+%
+% options.labelfile = filename string of the text file providing the label names of the analyzed brain regions.
+%                       Can be either 'none' if no such file is available or '*.txt',
+%                       see 'select_subcort_legend.txt' for an example.
+%                       If specified as 'none', brain regions will be labeled numerically.
+%
+%
 % options.output = filename string to output FD values to
 %
 %
 % OPTIONAL INPUTS:
 % options.boxsizes = list of numbers
 %                    Default: 2.^[0:4] (resolves to [1,2,4,8,16])
-%                    Specify what 'box sizes' (also applies to dilation algorithm) to use 
+%                    Specify what 'box sizes' (also applies to dilation algorithm) to use
 %                    when calculating FD.
 %                    Preferred to scale in powers of two.
 %
 % ----
 %
 % The calcFD toolbox is available from: http://cmadan.github.io/calcFD/.
-% 
+%
 % Please cite this paper if you use the toolbox:
-%   Madan, C. R., & Kensinger, E. A. (2016). Cortical complexity as a measure of 
+%   Madan, C. R., & Kensinger, E. A. (2016). Cortical complexity as a measure of
 %       age-related brain atrophy. NeuroImage, 134, 617-629.
 %       doi:10.1016/j.neuroimage.2016.04.029
 %
 % If you use the toolbox with subcortical/ventricular structures, please also cite:
-%   Madan, C. R., & Kensinger, E. A. (2017). Age-related differences in the structural 
-%       complexity of subcortical and ventricular structures. Neurobiology of Aging, 50, 87-95. 
+%   Madan, C. R., & Kensinger, E. A. (2017). Age-related differences in the structural
+%       complexity of subcortical and ventricular structures. Neurobiology of Aging, 50, 87-95.
 %       doi:10.1016/j.neurobiolaging.2016.10.023
 %
-% 
+%
 % 20160616 CRM
 % build 28
+%
+% 20180503 SK: modified to include text file with label names as input,
+% see 'options.labelfile' above and the examples in wrapper_sample.m and
+% wrapper_sample_subcort.m.
 
 % process optional inputs
 if ~isfield(options,'boxsizes')
     options.boxsizes = 2.^[0:4];
     % resolves to [1,2,4,8,16]
+end
+
+% 20180503 SK: check if label file is provided
+if strcmp(options.labelfile, 'none')
+    labelfile = 'none'              ;
+else
+    labelfile = options.labelfile   ;
 end
 
 % get full list of subjects if asked
@@ -123,7 +141,7 @@ for s = 1:length(subjects)
             % in cortical ribbon, GM = 42/3
             vol = (vol==3) | (vol==42);
             labels = 1;
-                        
+            
         case 'Dest_aparc'
             vol_fname = fullfile(subjectpath,subjects{s},'mri','aparc.a2009s+aseg.mgz');
             vol = load_mgh(vol_fname);
@@ -160,7 +178,7 @@ for s = 1:length(subjects)
             vol_mask = zeros(size(vol));
             for l = select(:)'
                 ll = find(sum(select==l,2)); % line number
-                % fix for limitation of 'each row to have the same number of values' 
+                % fix for limitation of 'each row to have the same number of values'
                 vx = vol==l;
                 if sum(vx) == 0
                     %disp(sprintf('No match for  %g.',l))
@@ -174,7 +192,7 @@ for s = 1:length(subjects)
             vol = vol_mask;
             labels = unique(vol);
             labels = setdiff(labels,0);
-
+            
         case 'DKT'
             vol_fname = fullfile(subjectpath,subjects{s},'mri','aparc.DKTatlas40+aseg.mgz');
             vol = load_mgh(vol_fname);
@@ -183,13 +201,13 @@ for s = 1:length(subjects)
             labels = labels(labels>999);
             % remove the 'unknown' regions
             labels = setdiff(labels,[ 1000 2000]);
-
+            
         case 'none'
             vol_fname = fullfile(subjectpath,[subjects{s} '.mgz']);
             vol = load_mgh(vol_fname);
             labels = unique(vol);
             labels = setdiff(labels,0);
-
+            
         otherwise
             % not sure what to do with that request...
             disp(sprintf('%s is not a valid parcellation scheme',options.aparc));
@@ -247,8 +265,11 @@ end
 
 if isfield(options,'output')
     % output FD txt file to working directory
-    calcFD_save(options.output,fd,subjects,labels);
+    
+    calcFD_save(options.output,fd,subjects,labels,labelfile); % 20180502 SK: modified to include labelfile argument
+    
+end
 end
 
 % delete debug temp file
-% delete([options.output(1:(end-4)) '.mat']) 
+% delete([options.output(1:(end-4)) '.mat'])

--- a/calcFD/calcFD_save.m
+++ b/calcFD/calcFD_save.m
@@ -1,14 +1,37 @@
-function calcFD_save(fname,fd,subjects,labels)
+function calcFD_save(fname,fd,subjects,labels,labelfile)
 % Output the FD values to a txt file
 % 20151024 CRM
+%
+% 20180503 SK: modified to read in the headers from label file if provided,
+% else labels are numerical
+%
 
-fid = fopen(fname,'w');
+% file identifier
+fid     = fopen(fname,'w')              ;
 
 % headers
-fprintf(fid,'%s\t','subID.calcFD');
-% 20151119
-% maybe improve later so col headers can be read from another file?
-fprintf(fid,'label%g\t',labels);
+fprintf(fid,'%s\t','subID.calcFD')      ;
+
+% no label file provided
+if strcmp(labelfile, 'none')
+    
+    fprintf(fid,'label%g\t',labels)                 ;
+    
+% if label file is provided read in column header names
+else
+    
+    % file identifier for label file
+    fid_legend = fopen(labelfile,'r')               ;
+    
+    % read col headers to cell
+    headers_cell = textscan(fid_legend, '%s')       ;
+    
+    % assign col headers to output
+    fprintf(fid, '%s\t', headers_cell{1}{:})        ;
+    
+end
+
+% new paragraph
 fprintf(fid,'\n');
 
 % write table

--- a/examples/lobes_legend.txt
+++ b/examples/lobes_legend.txt
@@ -1,0 +1,5 @@
+Frontal
+Parietal
+Temporal
+Occipital
+

--- a/examples/wrapper_sample.m
+++ b/examples/wrapper_sample.m
@@ -8,10 +8,12 @@ options.alg         = 'dilate';
 options.countFilled = 1;
 
 options.aparc       = 'Ribbon';
+options.labelfile   = 'none'  ;
 options.output      = sprintf('calcFD_%s_%s_%g_%s.txt',sample,options.aparc,options.countFilled,options.alg);
 tic;[fd,subjects]   = calcFD(subjects,subjectpath,options);toc
 
 options.aparc       = 'Dest_aparc';
 options.input       = 'lobe';
+options.labelfile   = 'lobes_legend.txt'; % 20180503 SK: provide legend text file for lobes 
 options.output      = sprintf('calcFD_%s_%s_%g_%s.txt',sample,options.aparc,options.countFilled,options.alg);
 tic;[fd,subjects]   = calcFD(subjects,subjectpath,options);toc

--- a/examples/wrapper_sample_subcort.m
+++ b/examples/wrapper_sample_subcort.m
@@ -1,4 +1,7 @@
 % 20160415 CRM
+% 20180502 SK: modified to read in label names from a text file 
+% if 'options.labelfile' is 'none', label names default to numerical 
+
 addpath('calcFD')
 
 sample              = 'IXI';
@@ -8,11 +11,15 @@ options.alg         = 'dilate';
 options.countFilled = 1;
 
 options.aparc       = 'Dest_select';
-% note, Dest_select can't have same FS-region in multiple txt-regions
+% note, Dest_select can't have same FS-region in multiple txt-regions, (SK: 
+% the first column in 'select_subcort.txt' refers to the left hemisphere)
+
 options.input       = 'subcort';
+options.labelfile   = 'select_subcort_legend.txt'; % 20180503 SK: provide label file for subcortical structures
 options.output      = sprintf('calcFD_%s_%s_%s_%g_%s.txt',sample,options.aparc,options.input,options.countFilled,options.alg);
 tic;[fd,subjects]   = calcFD(subjects,subjectpath,options);toc
 
-options.input       = 'ventricles';
+options.input       = 'ventricles'  ;
+options.labelfile   = 'none'        ;
 options.output      = sprintf('calcFD_%s_%s_%s_%g_%s.txt',sample,options.aparc,options.input,options.countFilled,options.alg);
 tic;[fd,subjects]   = calcFD(subjects,subjectpath,options);toc


### PR DESCRIPTION
Hey, I modified calcFD_save.m and calcFD.m to read the label names of the analyzed brain regions from a text file if provided, else labels remain numerical. The wrappers now include one example of each (i.e. once labels are read from a text file that is included in the examples folder and once labels remain numerical). Happy to hear what you think. Best, Stephan 